### PR TITLE
Suggestions only

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,108 @@
+md2tex
+======
+md2tex code by Thibault Friedrich. English translation by Rick Henderson.
+
+## NAME
+
+	
+	md2tex, convert Markdown into LaTex.
+
+## SYNOPSIS
+
+	md2tex [options] source.md 
+	md2tex [options] source.mardown
+	md2tex [options] source.txt
+	md2tex --configure-header header.tex
+	md2tex --configure-footer footer.tex
+
+## DESCRIPTION
+
+    Il s'agit d'un script permettant de générer du code latex à partir d'une
+    source formatée à l'aide du langage markdown. Il peut générer juste la
+    partie décrite par le fichier markdown mais en mode COMPLET, il peut aussi
+    générer l'ensemble d'un fichier latex compilable. Enfin, il peut aussi
+    générer le pdf correspondant au latex.
+
+	The given input file must be a file whose content is formatted
+	in markdown. It should be noted that the extension of the source file does not 
+	change the behavior of the converter.
+
+	By default the generated code is displayed on the standard output.
+
+## OPTIONS
+	
+	-a, --author
+        définit l'auteur du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défaut, le nom de l'auteur est "Unknown
+        author".
+
+	-c, --complete
+		active le mode COMPLET qui génére le code complet d'un fichier latex
+		capable de compiler en incorporant le code relatif au fichier d'entrée
+		à un fichier latex existant. Le header et le footer de ce fichier
+		existant sont disponibles dans ~/.md4tex/header.tex et
+		~/.md4tex/footer.tex.
+	
+	--configure-footer [footer]
+        remplace le fichier de footer par défaut par le nouveau fichier donné
+        en paramètre. Les prochains appels à md2tex utiliseront le nouveau
+        fichier.
+
+	--configure-header [header]
+        remplace le fichier de header par défaut par le nouveau fichier donné
+        en paramètre. Afin de pouvoir ultérieurement changer certaines valeurs
+        comme le titre, l'auteur ou la date, les emplacements prévus à cet
+        effet dans le nouveau header configuré doivent respectivement comporter
+        les chaines '@@@Title@@@', '@@@Author@@@' et '@@@Date@@@'. Les
+        prochains appels à md2tex utiliseront le nouveau fichier.
+
+	-d, --date
+        définit la date du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défault, la date est à \today.
+
+    --footer [footer]
+        définit le fichier source utilisé comme footer pour cet unique appel à
+        md2tex.
+
+    -h, --help
+        displays the help file (the README.md file)
+
+    --header [header]
+        defines the source file used as the header for the current output file 
+         
+	-o, --output [destintation]
+		defines the name of the destination file
+
+	-p, --pdf
+		active le mode COMPLET et génère le fichier pdf. Attention, si le
+		fichier de sortie n'est pas explicité par l'utilisation de l'option -o,
+		les fichiers source.tex et source.pdf sont crées où source désigne la
+		basename du fichier donné en entrée.
+
+	-t, --title
+        définit le titre du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défaut, le titre est "Unknown title".
+
+## UTILISATION
+
+    Pour utiliser ce script, il faut impérativement lancer le script
+    d'installation 'install.sh'. Une fois cela fait, il est possible de créer
+    un alias dans son fichier de configuration de shell vers le fichier
+    ~/.md2tex/md2tex.py
+
+## AUTEUR
+
+    Le code de ce script python a été écrit par Thibault Friedrich. En cas de
+    problème, de questions, de propositions d'améliorations, vous pouvez me
+    contacter à <thibault.friedrich@gmail.com>
+    
+    This is a python script written by Thibault Friedrich. In case of problems, questions 
+    or suggestions for improvement, you can contact him at <thibaut.friedrich@gmail.com>
+    
+    English translations added by Rick Henderson.
+
+## BUGS
+
+	There are no known bugs, though certain features of markdown have not been implemented.
+
+

--- a/README-fr.md
+++ b/README-fr.md
@@ -1,0 +1,105 @@
+md2tex
+======
+
+
+## NOM
+
+	
+	md2tex, convertisseur mardown vers latex
+
+## SYNOPSIS
+
+	md2tex [options] source.md 
+	md2tex [options] source.mardown
+	md2tex [options] source.txt
+	md2tex --configure-header header.tex
+	md2tex --configure-footer footer.tex
+
+## DESCRIPTION
+
+    Il s'agit d'un script permettant de générer du code latex à partir d'une
+    source formatée à l'aide du langage markdown. Il peut générer juste la
+    partie décrite par le fichier markdown mais en mode COMPLET, il peut aussi
+    générer l'ensemble d'un fichier latex compilable. Enfin, il peut aussi
+    générer le pdf correspondant au latex.
+
+	Le fichier donné en entré doit être un fichier dont le contenu est formatté
+	sous markdown. Il est à noté que l'extension du fichier source ne modifie en
+	rien au comportement du convertisseur.
+
+	Par défaut le code généré est affiché sur la sortie standard.
+
+## OPTIONS
+	
+	-a, --author
+        définit l'auteur du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défaut, le nom de l'auteur est "Unknown
+        author".
+
+	-c, --complete
+		active le mode COMPLET qui génére le code complet d'un fichier latex
+		capable de compiler en incorporant le code relatif au fichier d'entrée
+		à un fichier latex existant. Le header et le footer de ce fichier
+		existant sont disponibles dans ~/.md4tex/header.tex et
+		~/.md4tex/footer.tex.
+	
+	--configure-footer [footer]
+        remplace le fichier de footer par défaut par le nouveau fichier donné
+        en paramètre. Les prochains appels à md2tex utiliseront le nouveau
+        fichier.
+
+	--configure-header [header]
+        remplace le fichier de header par défaut par le nouveau fichier donné
+        en paramètre. Afin de pouvoir ultérieurement changer certaines valeurs
+        comme le titre, l'auteur ou la date, les emplacements prévus à cet
+        effet dans le nouveau header configuré doivent respectivement comporter
+        les chaines '@@@Title@@@', '@@@Author@@@' et '@@@Date@@@'. Les
+        prochains appels à md2tex utiliseront le nouveau fichier.
+
+	-d, --date
+        définit la date du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défault, la date est à \today.
+
+    --footer [footer]
+        définit le fichier source utilisé comme footer pour cet unique appel à
+        md2tex.
+
+    -h, --help
+        affiche le fichier d'aide (le fichier README.md)
+
+    --header [header]
+        définit le fichier source utilisé comme header pour cet unique appel à
+        md2tex.
+         
+	-o, --output [sortie]
+		définit le nom du fichier de sortie. 
+
+	-p, --pdf
+		active le mode COMPLET et génère le fichier pdf. Attention, si le
+		fichier de sortie n'est pas explicité par l'utilisation de l'option -o,
+		les fichiers source.tex et source.pdf sont crées où source désigne la
+		basename du fichier donné en entrée.
+
+	-t, --title
+        définit le titre du code latex généré. Cette option n'est utile que si
+        le mode COMPLET est activé. Par défaut, le titre est "Unknown title".
+
+## UTILISATION
+
+    Pour utiliser ce script, il faut impérativement lancer le script
+    d'installation 'install.sh'. Une fois cela fait, il est possible de créer
+    un alias dans son fichier de configuration de shell vers le fichier
+    ~/.md2tex/md2tex.py
+
+## AUTEUR
+
+    Le code de ce script python a été écrit par Thibault Friedrich.	En cas de
+    problème, de questions, de propositions d'améliorations, vous pouvez me
+    contacter à <thibault.friedrich@gmail.com>
+
+## BUGS
+
+	Il n'existe pas de bugs connus cependant, certaines fonctionnalités du
+	langage markdown n'ont pas encore été gérées.
+
+

--- a/README.md
+++ b/README.md
@@ -65,14 +65,13 @@ md2tex code by Thibault Friedrich. English translation by Rick Henderson.
         md2tex.
 
     -h, --help
-        affiche le fichier d'aide (le fichier README.md)
+        displays the help file (the README.md file)
 
     --header [header]
-        définit le fichier source utilisé comme header pour cet unique appel à
-        md2tex.
+        defines the source file used as the header for the current output file 
          
-	-o, --output [sortie]
-		définit le nom du fichier de sortie. 
+	-o, --output [destintation]
+		defines the name of the destination file
 
 	-p, --pdf
 		active le mode COMPLET et génère le fichier pdf. Attention, si le
@@ -93,9 +92,14 @@ md2tex code by Thibault Friedrich. English translation by Rick Henderson.
 
 ## AUTEUR
 
-    Le code de ce script python a été écrit par Thibault Friedrich.	En cas de
+    Le code de ce script python a été écrit par Thibault Friedrich. En cas de
     problème, de questions, de propositions d'améliorations, vous pouvez me
     contacter à <thibault.friedrich@gmail.com>
+    
+    This is a python script written by Thibault Friedrich. In case of problems, questions 
+    or suggestions for improvement, you can contact him at <thibaut.friedrich@gmail.com>
+    
+    English translations added by Rick Henderson.
 
 ## BUGS
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 md2tex
 ======
+md2tex code by Thibault Friedrich. English translation by Rick Henderson.
 
-
-## NOM
+## NAME
 
 	
-	md2tex, convertisseur mardown vers latex
+	md2tex, convert Markdown into LaTex.
 
 ## SYNOPSIS
 
@@ -23,11 +23,11 @@ md2tex
     générer l'ensemble d'un fichier latex compilable. Enfin, il peut aussi
     générer le pdf correspondant au latex.
 
-	Le fichier donné en entré doit être un fichier dont le contenu est formatté
-	sous markdown. Il est à noté que l'extension du fichier source ne modifie en
-	rien au comportement du convertisseur.
+	The given input file must be a file whose content is formatted
+in markdown. It should be noted that the extension of the source file does not 
+change the behavior of the converter.
 
-	Par défaut le code généré est affiché sur la sortie standard.
+	By default the generated code is displayed on the standard output.
 
 ## OPTIONS
 	
@@ -99,7 +99,6 @@ md2tex
 
 ## BUGS
 
-	Il n'existe pas de bugs connus cependant, certaines fonctionnalités du
-	langage markdown n'ont pas encore été gérées.
+	There are no known bugs, though certain features of markdown have not been implemented.
 
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ md2tex code by Thibault Friedrich. English translation by Rick Henderson.
     générer le pdf correspondant au latex.
 
 	The given input file must be a file whose content is formatted
-in markdown. It should be noted that the extension of the source file does not 
-change the behavior of the converter.
+	in markdown. It should be noted that the extension of the source file does not 
+	change the behavior of the converter.
 
 	By default the generated code is displayed on the standard output.
 

--- a/md2tex.py
+++ b/md2tex.py
@@ -121,16 +121,16 @@ for o, a in opts:
         if os.path.isfile(a):
             headerFilename = a;
         else:
-            print("L'argument doit être un chemin vers un fichier valide");
+            print("The argument must be a path to a valid file. L'argument doit être un chemin vers un fichier valide");
             sys.exit(2);
     elif o in ("--footer"):
         if os.path.isfile(a):
             footerFilename = a;
         else:
-            print("L'argument doit être un chemin vers un fichier valide");
+            print("The argument must be a path to a valid file. L'argument doit être un chemin vers un fichier valide.");
             sys.exit(2);
     elif o in ("-v","--version"):
-        print("md2tex version 1.0 sous licence GPL v3");
+        print("md2tex version 1.0 under licence GPL v3");
         sys.exit(0);
     else :
         usage();
@@ -168,7 +168,7 @@ try:
     source = re.sub(r'\n\t[0-9]+\. (.*)',r'\n\t\subitem \1',source);
 
 
-    # retour à la ligne
+    # retour à la ligne / Return a newline
     source = re.sub(r'  \n',r'\n\\newline\n',source,re.MULTILINE);
 
 

--- a/md2tex.py
+++ b/md2tex.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3.2
+# -*- coding: iso-8859-15 -*-
 # This file is part of md2tex.
 # 
 # 	Md2tex is free software: you can redistribute it and/or modify it under the
@@ -22,7 +23,7 @@ import re
 import subprocess
 
 def usage():
-    print("launch md4tex -h for the help");
+    print("launch md2tex -h for the help");
 
 
 try:
@@ -30,7 +31,7 @@ try:
 except getopt.GetoptError as err:
     # Affiche l'aide et quitte le programme
     print(err) # Va afficher l'erreur en anglais
-    usage() # Fonction à écrire rappelant la syntaxe de la commande
+    usage() # Fonction a ecrire rappelant la syntaxe de la commande. Function to display the command syntax.
     sys.exit(2)
 
 
@@ -229,4 +230,3 @@ try:
 
 except IOError as err:
     print(err);
- 

--- a/md2tex.py
+++ b/md2tex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.2
+#!/usr/bin/env python
 # -*- coding: iso-8859-15 -*-
 # This file is part of md2tex.
 # 
@@ -80,8 +80,6 @@ def writeTexFile(texFilename,source):
 if len(args) > 0:
     inputFilename = args[0]
     outputFilenameBase = re.sub(r'(.*).(txt|md|markdown)',r'\1',inputFilename);
-
-#inputFilename = sys.argv[1];
 
 for o, a in opts:
     if o in ("-p", "--pdf"):

--- a/md2tex.py
+++ b/md2tex.py
@@ -149,10 +149,9 @@ if len(args) == 0:
 try:
     fileSource=open(inputFilename,'r')
 
-    # Conversion en string 
+    # Read the entire source file into a string called source.
     source = fileSource.read()
     fileSource.close();
-
 
     source = re.sub(r'!\((.*) "(.*)"\)',r'\\begin{figure}\n\t\\includegraphics{\1}\n\t\\caption{\2}\n\\end{figure}',source);
 


### PR DESCRIPTION
I've made a bunch of changes to the README files which I intended for my own use, but if you want the English versions implemented into your own master branch you can use them.

One change I would suggest is in commit  8f83e9c, where I've added a comment to line 2 of the md2tex.py file which allows the file to run correctly on my English server. I was getting errors because of the French accent characters and was referred to https://www.python.org/dev/peps/pep-0263/ though I don't really know enough about encodings to guess at the encoding used on your machine or what is the best setting. The one I chose works for me.

I also corrected a spelling mistake in the usage line which referred to using `md4tex` instead of `md2tex` but I added into one of the other changes.
